### PR TITLE
add deploy to github releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: generic
 
+sudo: required
+
 dist: trusty
 
 services:
   - docker
 
 install:
-  - docker pull lamtev/latex-build-tools
+  - docker pull lamtev/latex
 
 matrix:
   include:
@@ -17,4 +19,13 @@ matrix:
 
 script:
   - chmod +x travis_build.sh
-  - docker run -v $TRAVIS_BUILD_DIR:/latex_templates lamtev/latex-build-tools /bin/bash -c " cd latex_templates && . ./travis_build.sh && build_latex_template $LATEX_TEMPLATE "
+  - docker run -v $TRAVIS_BUILD_DIR:/latex_templates lamtev/latex /bin/bash -c " cd latex_templates && . ./travis_build.sh && build_latex_template $LATEX_TEMPLATE "
+  - sudo chmod 777 ${TRAVIS_BUILD_DIR}/${LATEX_TEMPLATE}/${LATEX_TEMPLATE}.pdf
+
+deploy:
+  provider: releases
+  api_key: "$GITHUB_DEPLOY_TOKEN"
+  file: ${TRAVIS_BUILD_DIR}/${LATEX_TEMPLATE}/${LATEX_TEMPLATE}.pdf
+  skip_cleanup: true
+  on:
+    tags: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### Шаблоны для LaTeX'a
+### Шаблоны для LaTeX'a [![Build Status](https://travis-ci.org/ejiek/latex_templates.svg?branch=master)](https://travis-ci.org/ejiek/latex_templates)
 ======
 Здесь вы найдёте шаблоны [презентаций](https://github.com/ejiek/latex_templates/tree/master/presentation), [отчётов](https://github.com/ejiek/latex_templates/tree/master/report), а также выпускных работ ([бакалаврская](https://github.com/ejiek/latex_templates/tree/master/bachelor_thesis)).
 

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -12,11 +12,17 @@ build_latex_template()
   cd $LATEX_TEMPLATE
   
   pdflatex $LATEX_TEMPLATE.tex
-  if [ "$LATEX_TEMPLATE" == "bachelor_thesis" ] || [ "$LATEX_TEMPLATE" == "coursework" ]; then
-	bibtex $LATEX_TEMPLATE.aux
-  elif [ "$LATEX_TEMPLATE" == "bachelor_thesis" ]; then
-	makeindex $LATEX_TEMPLATE.nlo -s nomencl.ist -o $LATEX_TEMPLATE.nls
-  fi
+  case "$LATEX_TEMPLATE" in
+	"bachelor_thesis" )
+		bibtex $LATEX_TEMPLATE.aux
+		makeindex $LATEX_TEMPLATE.nlo -s nomencl.ist -o $LATEX_TEMPLATE.nls
+	;;
+	
+	"coursework" )
+		bibtex $LATEX_TEMPLATE.aux
+	;;
+  esac
+  
   pdflatex $LATEX_TEMPLATE.tex
   pdflatex $LATEX_TEMPLATE.tex
 


### PR DESCRIPTION
Данный пулл реквест добавляет развертывание pdf файлов шаблонов в _github releases_ при помощи _travis_,  исправляет баг в travis_build.sh, а также добавляет значок состояния сборки в README.md.

Travis развертывает артефакты сборки только в том случае, если коммиты тегированы. В любом другом случае этап развертывания пропускается.

@ejiek  необходимо в настройках _github_ создать [токен](https://github.com/settings/tokens/new) доступа к аккаунту (галочки в пункте **repo** достаточно) и в настройках _travis_ создать [переменную](https://travis-ci.org/ejiek/latex_templates/settings) **GITHUB_DEPLOY_TOKEN** со значением этого токена.
