### PR TITLE
extract chmod line to before_deploy section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
 script:
   - chmod +x travis_build.sh
   - docker run -v $TRAVIS_BUILD_DIR:/latex_templates lamtev/latex /bin/bash -c " cd latex_templates && . ./travis_build.sh && build_latex_template $LATEX_TEMPLATE "
+
+before_deploy:
   - sudo chmod 777 ${TRAVIS_BUILD_DIR}/${LATEX_TEMPLATE}/${LATEX_TEMPLATE}.pdf
 
 deploy:


### PR DESCRIPTION
Данный пулл реквест выделяет инструкцию
 `sudo chmod 777 ${TRAVIS_BUILD_DIR}/${LATEX_TEMPLATE}/${LATEX_TEMPLATE}.pdf`
 в отдельную секцию __before_deploy__, что позволяет выполнять эту инструкцию не во всех сборках, а только в тех, в которых это действительно необходимо, т.е помеченных тегом.